### PR TITLE
Fix HBO Max provider ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
   const TMDB_API_KEY = 'cbfde925a00faf1b31720306ddde1dea';
 
   // Provider codes for TMDb
-  const PROVIDERS = { netflix: 8, max: 384, disney: 337 };
+  const PROVIDERS = { netflix: 8, max: 1899, disney: 337 };
 
   // Storage for movies per provider
   const titles = { netflix: [], max: [], disney: [] };


### PR DESCRIPTION
## Summary
- update the TMDb provider code for the Max streaming service

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884ad4f9aac83208a80d9dd7be012d7